### PR TITLE
chore: Claude Code Projekt-Konfiguration (CLAUDE.md, /ship, /context-engineering)

### DIFF
--- a/.claude/commands/context-engineering.md
+++ b/.claude/commands/context-engineering.md
@@ -1,0 +1,207 @@
+# Context Engineering: Struktur einrichten & regelmäßig optimieren
+
+Richte die Claude-Code-Kontextstruktur im aktuellen Projekt ein **oder** optimiere die bestehende. Dieses Command ist **wiederholbar gedacht**: bei jedem Lauf prüfst du, was existiert, verbesserst es und hältst es aktuell. Passe alle Inhalte an den erkannten Projektkontext an (Sprache, Tech-Stack, Domäne). Template, kein starres Schema.
+
+**Leitprinzip (aus Anthropic Best-Practices):** CLAUDE.md & Rules sind Kontext, keine erzwungene Konfiguration. Je spezifischer und schlanker, desto zuverlässiger befolgt. Für jede Zeile gilt: *„Würde ihr Entfernen Claude Fehler machen lassen?"* Wenn nein → löschen oder in Hook/Skill verschieben. Behandle CLAUDE.md wie Code: regelmäßig reviewen und prunen.
+
+---
+
+## PHASE 0: BESTANDSAUFNAHME & MODUS-ERKENNUNG
+
+Verschaffe dir zuerst einen Überblick, dann entscheide den Lauf-Modus:
+
+```
+ls CLAUDE.md .claude/CLAUDE.md CLAUDE.local.md AGENTS.md 2>/dev/null
+ls .claude/rules/ .claude/skills/ .claude/agents/ .claude/settings.json 2>/dev/null
+wc -l CLAUDE.md 2>/dev/null   # Größe prüfen (Ziel < 200)
+```
+Auto-Memory: Verzeichnis `~/.claude/projects/<project>/memory/` existiert bereits (von Claude selbst verwaltet) — nur Konvention kennen, bei Bedarf pflegen.
+
+**Modus bestimmen:**
+- **Erstlauf (Bootstrap):** keine CLAUDE.md und kein `.claude/rules/` → gehe primär durch Phase 1.
+- **Wartungslauf (Audit & Optimize):** Struktur existiert → Phase 1 nur als Lückenfüller, Schwerpunkt auf **Phase 2 (Audit)**.
+
+Beide Modi durchlaufen am Ende Phase 3 (Research) und Phase 4 (Validierung).
+
+---
+
+## PHASE 1: STRUKTUR EINRICHTEN / VERVOLLSTÄNDIGEN
+
+### 1.1 Verzeichnisse
+Stelle sicher, dass existieren (nur was gebraucht wird):
+```
+.claude/
+  rules/      # Modulare, path-scoped Regeln
+  commands/   # Custom Slash-Commands (= Skills)
+```
+Optional je nach Bedarf: `.claude/skills/`, `.claude/agents/`.
+
+### 1.2 CLAUDE.md (Projekt-Root oder `.claude/CLAUDE.md`)
+Erstelle/aktualisiere; Ziel **unter 200 Zeilen** (kürzer = bessere Adherence). Tipp: `/init` generiert einen Startpunkt aus dem Code (bzw. interaktiv mit `CLAUDE_CODE_NEW_INIT=1`); existiert CLAUDE.md, schlägt `/init` Verbesserungen vor statt zu überschreiben.
+
+```markdown
+# [Projektname] - Projektregeln
+
+## Projekt-Kontext
+[1-3 Sätze: Domäne, Tech-Stack, Besonderheit]
+
+## Feedback-Loops   ← höchster ROI
+[Exakte Build-/Test-/Lint-/Run-Commands, die Claude nicht erraten kann]
+
+## Konventionen
+[Nur was vom Default abweicht — was ein Linter erzwingt, NICHT hierher]
+
+## Arbeitsweise
+- Plan first bei nicht-trivialen Aufgaben; einfachste Lösung; Root-Cause statt Pflaster
+- Nur ändern was angefragt wurde; bei Unsicherheit nachfragen
+- Erfolg mit Evidenz belegen (Testausgabe/Screenshot), nicht behaupten
+
+## Kontext-Management
+- >70% Kontext: /compact (mit Fokus-Instruktion); zwischen Tasks /clear
+- Recherche über Subagenten (eigener Kontext, nur Summary zurück)
+
+## Kompaktierung
+Beim Kompaktieren immer beibehalten: Entscheidungen + Begründungen,
+offene Fragen, geänderte Dateien, Test-Commands, aktueller Task-Kontext
+```
+Nützliche CLAUDE.md-Features:
+- **`@path`-Imports**: `@README.md`, `@package.json`, `@docs/x.md` referenzieren statt duplizieren (laden mit; in Backticks = kein Import).
+- **HTML-Kommentare** `<!-- Maintainer-Notiz -->` werden vor dem Laden entfernt → Notizen ohne Token-Kosten.
+- **Ladehierarchie** (additiv, spezifisch gewinnt): managed policy → user `~/.claude/CLAUDE.md` → project `./CLAUDE.md`/`.claude/CLAUDE.md` → `CLAUDE.local.md`. Subdir-CLAUDE.md laden on-demand.
+- **AGENTS.md** vorhanden? → `@AGENTS.md` importieren oder symlinken statt duplizieren.
+
+### 1.3 Modulare Rules (`.claude/rules/`)
+Ein Thema pro Datei (`testing.md`, `api-design.md`); rekursiv inkl. Unterordnern entdeckt; Symlinks zum Teilen über Projekte; User-Level `~/.claude/rules/` für persönliche Defaults.
+
+**Immer (ohne `paths` = immer aktiv, Priorität wie CLAUDE.md):**
+1. `vertraulichkeit.md` — keine sensiblen Daten an externe Dienste. ⚠️ Advisory! Harte Sperre → **Hook/Permission** (siehe 1.5).
+2. `output-format.md` — Antwortsprache, Formatierung, Quellverweis-Format.
+
+**Path-scoped (lädt nur bei passenden Dateien — spart Kontext):**
+```yaml
+---
+paths:
+  - "src/**/*.{ts,tsx}"   # Brace-Expansion & mehrere Muster erlaubt
+  - "tests/**/*.test.ts"
+---
+# TypeScript-Regeln
+```
+⚠️ **Limitation:** Path-Rules triggern beim **Read** passender Dateien, **nicht beim Write/Neuanlegen**. Für neu erzeugte Dateien greifen sie evtl. nicht.
+
+### 1.4 Memory-System
+Auto-Memory ist seit **v2.1.59** nativ & standardmäßig an. Claude pflegt `~/.claude/projects/<project>/memory/` selbst (per Repo, über Worktrees geteilt, maschinen-lokal). Kein manueller Init nötig.
+- **Laden:** nur erste **200 Zeilen oder 25 KB** von `MEMORY.md` (was zuerst greift) → schlank halten, Details in Topic-Files.
+- **`MEMORY.md`** = Index (eine Zeile/Memory). **Topic-Files** = ein Fakt/Datei, on-demand gelesen.
+- **Konvention dieses Setups** (über den offiziellen „plain markdown"-Standard hinaus): Frontmatter `name` / `description` / `metadata.type` mit Typen `user | feedback | project | reference`; bei `feedback`/`project` zusätzlich `**Why:**` + `**How to apply:**`; Verlinkung mit `[[name]]`.
+- Vor dem Speichern Duplikate prüfen, lieber aktualisieren; nichts speichern was Repo/Git/CLAUDE.md schon abdecken.
+- Konfig bei Bedarf: `autoMemoryEnabled`, `autoMemoryDirectory` (settings.json), `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`.
+- Audit/Editieren live mit **`/memory`**.
+
+### 1.5 Enforcement vs. Advisory (wichtig)
+CLAUDE.md & Rules formen Verhalten, **garantieren** es aber nicht. Muss eine Regel *immer* halten:
+- **Hook** (`.claude/settings.json`, z.B. `PreToolUse` blockt, `PostToolUse` lintet) — deterministisch.
+- **Permissions/Sandbox** — `permissions.deny` für Tools/Pfade.
+Beispiel: „nie `.env` editieren", „kein Push auf main", „Secrets nicht raussenden" → Hook, nicht nur Rule.
+
+### 1.6 CLAUDE.local.md (optional, nicht committen)
+Persönliche Session-Notizen; in `.gitignore`. Für Worktree-übergreifend stattdessen `@~/.claude/...` importieren.
+
+---
+
+## PHASE 2: AUDIT & OPTIMIERUNG  ← Kern des wiederkehrenden Laufs
+
+Gehe bestehende Struktur kritisch durch und verbessere aktiv:
+
+**CLAUDE.md prunen** (Faustregel: *würde Entfernen Fehler verursachen?*):
+| ✅ behalten | ❌ entfernen |
+|---|---|
+| Commands, die Claude nicht erraten kann | Was Claude aus dem Code liest |
+| Konventionen, die vom Default abweichen | Standard-Sprachkonventionen |
+| Test-Runner/-Anweisungen | Detaillierte API-Doku (→ Skill/Link) |
+| Repo-Etikette (Branch/PR) | Häufig ändernde Infos |
+| Architektur-Entscheidungen, Gotchas | Datei-für-Datei-Beschreibungen |
+| Env-Quirks | Selbstverständliches („sauberen Code schreiben") |
+| Was ein **Linter erzwingt** → raus | Aspirationen statt verifizierbarer Regeln |
+
+**Weitere Audit-Checks:**
+- **Größe:** CLAUDE.md > 200 Zeilen? → in `.claude/rules/` (path-scoped) aufteilen oder Reference-Inhalt in Skills auslagern.
+- **Konflikte/Duplikate:** widersprüchliche Regeln über CLAUDE.md / nested CLAUDE.md / `.claude/rules/` entfernen (Claude wählt sonst willkürlich). Keine Doppelung CLAUDE.md ↔ Rules ↔ Skills.
+- **Richtiges Mechanismus-Fit** (Entscheidungsmatrix, siehe Referenz): Reference-Wissen/Workflows → **Skill**; immer-aktiv & broad → **CLAUDE.md**; pfad-/dateispezifisch → **Rule**; muss-immer-passieren → **Hook**; viel-Datei-Recherche → **Subagent**; externe Systeme → **MCP**.
+- **Advisory, das hart sein sollte** → in Hook/Permission überführen.
+- **Memory-Hygiene:** `MEMORY.md` schlank? Veraltete/falsche Topic-Files löschen.
+- **Monorepo:** irrelevante Vorfahren-CLAUDE.md via `claudeMdExcludes` (settings.local.json) ausschließen.
+- **Debugging:** unklar was lädt? `InstructionsLoaded`-Hook oder `/memory` nutzen.
+
+---
+
+## PHASE 3: RESEARCH LOOP — AKTUALITÄTSPRÜFUNG
+
+Da Claude Code sich schnell ändert: **vor** dem Übernehmen offizielle Docs prüfen statt aus dem Gedächtnis. Web-Suchen parallel (Jahr im Query an aktuelles Jahr anpassen):
+1. `"Claude Code CLAUDE.md best practices <Jahr>"`
+2. `"Claude Code context engineering update <Jahr>"`
+3. `"Claude Code .claude/rules new features <Jahr>"`
+4. `"Anthropic Claude Code skills agents memory update <Jahr>"`
+
+Dann **kanonische Quellen** (unten) gegenchecken auf: neue CLAUDE.md/Rules-Features (Frontmatter-Felder), Memory-Änderungen (Typen/Limits), neue Mechanismen, neue Versionen.
+- Änderungen gefunden → Struktur **und dieses Command** aktualisieren.
+- Keine → bestätigen, dass die Struktur aktuell ist (mit Datum/Version notieren).
+
+*Beobachtungshorizont (Preview, vor Nutzung verifizieren):* „Dreaming" (Research Preview) & Managed-Agents-Memory (Beta); bekannter Bug — User-Level `~/.claude/rules/` mit `paths:` wird teils ignoriert.
+
+---
+
+## PHASE 4: VALIDIERUNG
+
+- [ ] CLAUDE.md existiert, < 200 Zeilen, führt mit Feedback-Loops/Commands
+- [ ] Keine Duplikation/Konflikte zwischen CLAUDE.md, Rules, Skills
+- [ ] Keine Regel drin, die ein Linter erzwingt; nichts Aspirationales
+- [ ] `.claude/rules/` ≥ 2 Files, ≥ 1 mit `paths`-Scoping
+- [ ] Harte Sicherheits-/Schutzregeln als Hook/Permission, nicht nur Advisory
+- [ ] `MEMORY.md` schlank, ≥ 1 korrektes Topic-File (Konvention dieses Setups)
+- [ ] Reference-/Workflow-Inhalt liegt in Skills, nicht in CLAUDE.md
+- [ ] Research-Datum/CC-Version notiert
+
+---
+
+## REFERENZ
+
+### Mechanismus-Entscheidungsmatrix (offiziell)
+| Mechanismus | Lädt | Am besten für |
+|---|---|---|
+| **CLAUDE.md** | jede Session, voll | „Immer X"-Regeln, Commands, Architektur |
+| **.claude/rules/** | jede Session **oder** bei passenden Files (`paths`) | Sprach-/Verzeichnis-spezifische Regeln |
+| **Skill** (`.claude/skills/<n>/SKILL.md`) | on-demand (auto oder `/name`) | Reference-Wissen, wiederholbare Workflows |
+| **Subagent** (`.claude/agents/`) | bei Spawn, isolierter Kontext | viel-Datei-Recherche, parallele Spezialisten |
+| **Hook** (settings.json) | bei Lifecycle-Event | Erzwingen (Lint, Block, Log) — deterministisch |
+| **MCP** | Session-Start (Tool-Namen) | externe Systeme/Daten |
+
+„Build over time"-Trigger: Convention 2× falsch → CLAUDE.md · gleiches Prompt wiederholt → Skill · soll immer passieren → Hook · Output flutet Kontext → Subagent · externes System → MCP.
+
+### Context-Window-Budget
+| Füllstand | Aktion |
+|---|---|
+| 0-50% | frei arbeiten |
+| 50-70% | aufmerksam |
+| 70-90% | `/compact <fokus>` |
+| 90%+ | `/clear` / neue Session |
+Nach 2 erfolglosen Korrekturen am selben Punkt: `/clear` + besseres Initial-Prompt.
+
+### Progressive Disclosure
+MEMORY.md-Index & CLAUDE.md = immer geladen · Rules path-scoped & Topic-Files & Skills = on-demand · Subagenten = isolierter Kontext.
+
+---
+
+## QUELLEN (kanonisch, vor Antwort prüfen statt aus Gedächtnis)
+- https://code.claude.com/docs/en/memory — CLAUDE.md, `.claude/rules/`, Auto-Memory
+- https://code.claude.com/docs/en/best-practices — Kontext, Verifikation, CLAUDE.md-Pflege
+- https://code.claude.com/docs/en/features-overview — Entscheidungsmatrix Skills/Hooks/Subagents/MCP
+- https://code.claude.com/docs/en/skills — Skills
+- https://code.claude.com/docs/en/hooks-guide — Hooks (Enforcement)
+- https://code.claude.com/docs/en/sub-agents — Subagenten (+ persistente Memory)
+- https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents — Hintergrund
+
+*Letzte Aktualitätsprüfung: 2026-06-24 (Claude Code Auto-Memory v2.1.59).*
+
+---
+
+**ANWEISUNG:** Phase 0 (Modus erkennen) → Phase 1 (einrichten/vervollständigen) → Phase 2 (Audit & Optimierung) → Phase 3 (Research) → Phase 4 (Validierung). Im Wartungslauf liegt der Schwerpunkt auf Phase 2. Starte sofort mit Phase 0.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,104 @@
+---
+description: Änderungen verschiffen — Branch anlegen, selektiv committen, rebasen, verifizieren, pushen und einen PR mit Release Note + Confidence erstellen. Nutze diesen Skill immer, wenn der User seine Arbeit committen, pushen, "shippen", einen PR/Pull Request öffnen oder Änderungen abschließen/abgeben will — auch wenn er nur "mach nen PR", "push das", "commit & ship" o.Ä. sagt.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+## Your Task
+
+Bringe die aktuellen Änderungen sauber auf GitHub: passenden Branch wählen, relevante Dateien committen, auf den Default-Branch rebasen, verifizieren, pushen und einen PR mit Release Note und Confidence öffnen. Am Ende die PR-URL ausgeben.
+
+Arbeite die Schritte der Reihe nach ab, aber denk mit: Wenn ein Schritt nicht zutrifft (z.B. nichts zu committen, PR existiert schon), erkläre kurz warum du ihn überspringst, statt blind weiterzumachen.
+
+### 1. Änderungen analysieren
+- `git status` – untracked und geänderte Dateien
+- `git diff` und `git diff --staged` – was sich inhaltlich ändert (brauchst du gleich für Commit-Message, Branch-Name und Release Note)
+- `git log --oneline -5` – Commit-Stil des Repos übernehmen (Sprache, Prefix-Konvention)
+
+Wenn es nichts zu committen gibt **und** der lokale Branch nicht ungepusht ist: sag das dem User und brich ab — es gibt nichts zu shippen.
+
+### 2. Branch-Strategie
+Ermittle zuerst den Default-Branch, statt `main` anzunehmen (Repos heißen oft `master`, `develop` o.Ä.):
+```bash
+DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')
+# Fallback, falls origin/HEAD nicht gesetzt ist:
+[ -z "$DEFAULT" ] && DEFAULT=$(git remote show origin | sed -n 's/.*HEAD branch: //p')
+```
+- **Auf dem Default-Branch?** → neuen Branch abzweigen. Name aus dem Inhalt der Änderungen ableiten, Konvention `feat/…`, `fix/…`, `refactor/…`, `chore/…`. `git checkout -b <branch-name>`
+- **Schon auf einem Feature-Branch?** → dort weiterarbeiten, **keinen** neuen Branch anlegen. So landen zusammengehörige Commits auf demselben Branch/PR.
+
+### 3. Staging & Commit
+- **Selektiv stagen**, nicht `git add -A`/`.`. Jede Datei bewusst hinzufügen — so committest du nichts versehentlich (Secrets, lokale Configs, Debug-Artefakte). Sichte vorher, was die Änderung wirklich umfasst.
+- Keine `.env`, Credentials oder großen Binaries.
+- Commit-Message: kurz, **Englisch**, mit Prefix (`feat:`, `fix:`, `refactor:`, `chore:` …), passend zum Repo-Stil.
+- Co-Author-Tag des **aktuell aktiven** Claude-Modells anhängen (nicht hartkodiert lassen — Modellversionen veralten). Format:
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  ```
+  Falls die Session/das Repo eine andere Co-Author-Konvention vorgibt, diese verwenden.
+
+### 4. Rebase auf den Default-Branch
+Vor dem Push aktuellen Stand holen, damit der PR konfliktfrei mergebar ist:
+- `git fetch origin "$DEFAULT"`
+- `git rebase "origin/$DEFAULT"`
+- **Konflikte** → anzeigen und User fragen, **nicht** automatisch auflösen. Du kennst die fachliche Intention beider Seiten nicht sicher; eine falsche Auflösung ist schwer zu entdecken.
+- Clean → weiter.
+
+### 5. Verifizieren (vor dem Push)
+Lass die schnellen Checks des Projekts laufen, damit der PR nicht direkt rot wird. Ermittle die Befehle aus `package.json` (`scripts.lint`, `scripts.test`) bzw. den Feedback-Loops in `CLAUDE.md`:
+- Lint und Unit-Tests ausführen (z.B. `npm run lint`, `npm test`).
+- Langsame Full-/SSR-Builds nur, wenn der User es will oder es keine Tests gibt — sie kosten Minuten.
+- **Schlägt ein Check fehl** → stoppen, Fehler zeigen, mit dem User klären (Fix vor dem PR ist billiger als Rework danach). Nicht stillschweigend pushen.
+- Keine Checks im Projekt gefunden → kurz erwähnen und überspringen.
+
+### 6. Pushen
+- `git push -u origin <branch-name>`
+- War der Branch schon gepusht und es gab einen Rebase: vor `--force-with-lease` den User fragen.
+
+### 7. PR erstellen via `gh pr create`
+Prüfe bei Bedarf `gh auth status`; existiert für den Branch schon ein PR (`gh pr view`), aktualisiere/verweise statt einen zweiten zu öffnen.
+
+- Titel: kurz, unter 70 Zeichen.
+- **Body auf Deutsch** (Projektsprache), mit Summary, **Release Note (Pflicht)**, Test Plan und **Confidence (Pflicht)**:
+  ```
+  ## Summary
+  - …
+
+  ## Release Note
+  **Kategorie:** <Neue Funktion | Fehlerbehebung | Optimierung | intern>
+
+  <Bei „intern": ein Satz Begründung, warum nicht kundenrelevant (z.B. „Test-Stabilisierung", „CI-Konfiguration", „internes Refactoring ohne UI-/API-Wirkung"). Damit endet die Sektion.>
+
+  <Sonst: 1 bis 4 Sätze in Sie-Form, kundennah, ohne interne Begriffe. Beschreibt, was der Kunde nun kann/sieht, nicht was technisch geändert wurde.>
+
+  ## Test plan
+  - [ ] …
+
+  ## Confidence
+  **<0-100>/100** – 1-2 Sätze: Selbsteinschätzung, wie robust/korrekt die Änderung ist (kommt der PR ohne Rework durch?). Was zieht runter (ungeprüfter Pfad, fehlende Tests, fragwürdige Annahme, externes System nicht getestet)? Rein informativ, nicht blockierend.
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  ```
+
+**Kategorisierungs-Heuristik** (Default; User kann überschreiben):
+- `feat:`/`feature:` → meist „Neue Funktion"
+- `fix:`/`bug:`/`hotfix:` → meist „Fehlerbehebung"
+- `perf:`/`ux:`/`style:` (UI) → meist „Optimierung"
+- `chore:`/`test:`/`ci:`/`build:`/`docs:`/`refactor:` ohne UI-/API-Wirkung → „intern"
+- Unsicher? Geänderte Dateien prüfen: nur `tests/`, `.github/`, `infrastructure/`, `docs/` betroffen → „intern".
+
+**Schreibstil Release Note** (Quelle der Wahrheit ist der `/release-notes`-Skill — bei Abweichungen dort nachsehen). Diese Regeln existieren, weil die Note direkt bei B2B-Kunden im Handwerk/Bau landet:
+- Sie-Form.
+- Echte Umlaute (ä, ö, ü, ß), kein ae/oe/ue/ss.
+- Kein Em-Dash (U+2014); nur Halbgeviertstrich (U+2013) oder Bindestrich.
+- Domain-Wording aus den i18n-Locales übernehmen (`frontend/src/locales/de.json` u.a.), nicht selbst übersetzen — sonst weicht die Note vom Produkt-Vokabular ab.
+- Keine Beträge/Zahlen/Prozentsätze, die nicht aus dem Code stammen.
+- Keine Aussagen über zukünftige Releases („folgt später").
+- Kein externes Marketing-/Rechtswissen ohne klaren Code-/PR-Beleg.
+- Keine internen Begriffe (Service-/Branch-/Tabellen-/Hook-Namen) — die sagen dem Kunden nichts.
+
+### 8. PR-URL ausgeben
+
+## Guardrails
+- **Keine Secrets committen.** Deshalb selektiv stagen (Schritt 3) und vor dem Commit sichten — ein versehentlich committetes Credential ist in der Historie schwer zu tilgen.
+- **Kein `--force`.** Es überschreibt fremde Commits unwiderruflich. `--force-with-lease` ist sicherer (bricht ab, wenn jemand anderes gepusht hat) und nur nach Rebase mit User-Bestätigung erlaubt.
+- **Kein `--no-verify`.** Pre-commit/-push-Hooks sind die Qualitäts-/Sicherheitsnetze des Repos; sie zu umgehen verschiebt Probleme nur in den PR.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Claude Code – personal/local settings (not shared)
+.claude/settings.local.json
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Personal homepage (markuskollers.de) — an Angular 11 app with server-side rendering (Angular Universal / Express) and a PWA service worker. Deployed to Google App Engine.
+
+## Commands
+
+- `ng serve` — dev server (client-side only) at http://localhost:4200, live reload.
+- `npm run dev:ssr` — dev server with SSR (`ng run markuskollers-de:serve-ssr`); use this to test SSR-specific behavior.
+- `npm run build` — production client build (`ng build -c production`).
+- `npm run build:ssr` — full production build of both client and server bundles (slow, several minutes); output in `dist/browser` and `dist/server`.
+- `npm start` / `npm run serve:ssr` — run the built SSR server (`node dist/server/main.js`).
+- `npm test` — single-run unit tests with coverage (Karma + Jasmine, headless, no watch). Use `ng test` for watch mode during development.
+- `ng test --include='**/some.component.spec.ts'` — run a single spec file.
+- `npm run lint` — TSLint (`ng lint`).
+- `npm run e2e` — Protractor end-to-end tests.
+- `npm run deploy` — deploy to GCP App Engine (`markuskollers-de` project). Normally done by CI, not manually.
+- `npm run bundle-report` — build with stats and open webpack-bundle-analyzer.
+
+## Architecture
+
+**SSR rendering pipeline.** Three bootstrap entry points: `src/main.ts` (browser), `src/main.server.ts` (server platform), and `server.ts` (Express host). At runtime the Express app (`server.ts`) renders routes via `ngExpressEngine` using `AppServerModule`. The server redirects `www.` → apex domain and serves static assets from `dist/browser` with 1y cache before falling back to Universal rendering. Code that touches browser-only globals (`window`, `ga`, etc.) must be guarded with `isPlatformBrowser(PLATFORM_ID)` — see `analytics.service.ts` for the pattern.
+
+**Module/page structure.** `AppModule` (`app.module.ts`) is the root; `AppServerModule` (`app.server.module.ts`) wraps it for SSR and adds the `UniversalInterceptor`. Each route under `src/app/pages/*` is a lazy-loaded feature module with its own `*-routing.module.ts` (see `app-routing.module.ts`). Routes: `''` (landing), `blog`, `imprint`, `privacy`. Shared layout (header, footer) and helpers live in `src/app/shared/`.
+
+**UniversalInterceptor** (`shared/helper/interceptors/universal-interceptor.ts`) rewrites relative HTTP request URLs to absolute ones during SSR, because the server has no implicit origin. Registered only in `AppServerModule`.
+
+**Styling/theming.** Angular Material with a custom SCSS theme in `src/styles/theme.scss`. Per-component theme partials are named `_<component>-theme.scss` and composed into the global theme (not loaded via the component's `styleUrls`). Shared SCSS variables: `src/styles/breakpoints.scss` (`$mat-xs/sm/md/lg`) and `src/styles/constants.scss` (`$width`, `$padding`).
+
+## Conventions (enforced by TSLint)
+
+- Component selectors: element, kebab-case, prefix `mk-` (e.g. `mk-header`). Directive selectors: attribute, camelCase, prefix `mk`.
+- Single quotes; max line length 140; no trailing commas; leading underscore allowed for variable names (e.g. private `_router`).
+- `lodash` and `rxjs/Rx` imports are blacklisted.
+- 2-space indentation, final newline, no trailing whitespace (`.editorconfig`).
+
+## CI/CD
+
+CircleCI (`.circleci/config.yml`) on every branch: install → `build:ssr` → `npm test` → upload coverage to Code Climate. Deploy to GCP App Engine runs only on `master`. Note the runtime targets Node 10 (`app.yaml`, CI image).


### PR DESCRIPTION
## Summary
- `CLAUDE.md` ergänzt: Build-/Test-/Lint-Commands, SSR-Render-Pipeline (main.ts/main.server.ts/server.ts), lazy-geladene Page-Module, UniversalInterceptor, Theming-Konvention und TSLint-Regeln (`mk-` Prefix etc.)
- Neuer `/context-engineering`-Command: richtet die Claude-Code-Kontextstruktur ein und optimiert sie wiederholbar (Modus-Erkennung Erstlauf/Wartung, Audit-Phase, Aktualitätsprüfung gegen die offiziellen Docs)
- Neuer `/ship`-Skill: Branch → selektiver Commit → Rebase → Verifikation → Push → PR mit Release Note + Confidence; erkennt den Default-Branch automatisch und nutzt das aktuelle Modell im Co-Author-Tag
- `.gitignore`: persönliche Claude-Code-Dateien ausgeschlossen (`settings.local.json`, `CLAUDE.local.md`)

## Release Note
**Kategorie:** intern

Reine Entwickler-Tooling- und Dokumentationskonfiguration für Claude Code ohne UI-/API-Wirkung – nicht kundenrelevant.

## Test plan
- [ ] Nur Doku/Config geändert (kein Code unter `src/`) – Lint/Tests nicht betroffen
- [ ] `settings.local.json` wird nicht versioniert (lokal verifiziert)
- [ ] `/ship` und `/context-engineering` erscheinen als Slash-Commands

## Confidence
**95/100** – Reine Markdown-/Config-Dateien ohne Laufzeitwirkung, daher sehr geringes Risiko. Abzug, weil die Skill-Workflows (Rebase/Push/PR, Default-Branch-Erkennung) noch nicht in jedem Edge-Case end-to-end durchgespielt wurden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)