### PR TITLE
feat: One-Pager komplett (Header, Kontakt, Footer, Rechtsseiten)

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,0 +1,52 @@
+---
+import { useTranslations } from '../i18n/utils';
+
+interface Props {
+  lang: 'de' | 'en';
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang);
+---
+
+<section id="kontakt" class="scroll-mt-20 border-t border-border">
+  <div class="mx-auto grid max-w-5xl gap-10 px-6 py-16 md:grid-cols-[1.4fr_1fr] md:items-end md:py-24">
+    <div>
+      <p class="flex items-center gap-3 font-mono text-xs uppercase tracking-[0.2em] text-accent-text">
+        <span aria-hidden="true" class="h-px w-6 bg-accent"></span>
+        {t('contact.eyebrow')}
+      </p>
+      <h2 class="mt-5 font-display text-4xl font-light leading-tight tracking-tight md:text-5xl">
+        {t('contact.lead')}
+        <br />
+        <span class="text-accent-text">{t('contact.leadAccent')}</span>
+      </h2>
+    </div>
+    <div class="flex flex-col items-start gap-4 md:items-end">
+      <a
+        href="mailto:mail@markuskollers.de"
+        class="group inline-flex items-center gap-2 rounded-full bg-accent px-6 py-3 font-medium text-white transition hover:opacity-90"
+      >
+        mail@markuskollers.de
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="size-[1.05em] transition-transform group-hover:translate-x-0.5"
+          aria-hidden="true"
+        >
+          <path d="M5 12h14"></path>
+          <path d="m13 6 6 6-6 6"></path>
+        </svg>
+      </a>
+      <div class="flex items-center gap-4 font-mono text-xs uppercase tracking-wider text-muted">
+        <a href="https://www.linkedin.com/in/markus-kollers" target="_blank" rel="noopener" class="transition hover:text-ink">LinkedIn</a>
+        <span aria-hidden="true">·</span>
+        <a href="https://github.com/mkollers" target="_blank" rel="noopener" class="transition hover:text-ink">GitHub</a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,23 @@
+---
+import { useTranslations } from '../i18n/utils';
+
+interface Props {
+  lang: 'de' | 'en';
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang);
+const imprintHref = lang === 'de' ? '/impressum' : '/en/imprint';
+const privacyHref = lang === 'de' ? '/datenschutz' : '/en/privacy';
+---
+
+<footer class="border-t border-border">
+  <div class="mx-auto flex max-w-5xl flex-col gap-3 px-6 py-8 font-mono text-xs text-muted sm:flex-row sm:items-center sm:justify-between">
+    <span>© 2026 Markus Kollers</span>
+    <div class="flex items-center gap-4">
+      <a href={imprintHref} class="transition hover:text-ink">{t('footer.imprint')}</a>
+      <span aria-hidden="true">·</span>
+      <a href={privacyHref} class="transition hover:text-ink">{t('footer.privacy')}</a>
+    </div>
+  </div>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,48 @@
+---
+import { useTranslations } from '../i18n/utils';
+
+interface Props {
+  lang: 'de' | 'en';
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang);
+const home = lang === 'de' ? '/' : '/en/';
+---
+
+<header class="mx-auto flex max-w-5xl items-center justify-between gap-6 px-6 py-5">
+  <a href={home} class="flex items-center gap-2.5 font-display font-medium text-ink">
+    <span aria-hidden="true" class="grid size-8 place-items-center rounded-md bg-ink font-mono text-xs font-medium text-bg"> MK </span>
+    Markus Kollers
+  </a>
+  <nav class="flex items-center gap-5 font-mono text-xs uppercase tracking-wider" aria-label="Navigation">
+    <a href={`${home}#schwerpunkte`} class="hidden text-muted transition hover:text-ink sm:inline">{t('nav.highlights')}</a>
+    <a href={`${home}#kontakt`} class="hidden text-muted transition hover:text-ink sm:inline">{t('nav.contact')}</a>
+    <span aria-hidden="true" class="hidden h-3 w-px bg-border sm:inline-block"></span>
+    <span class="flex items-center gap-2">
+      {
+        lang === 'de' ? (
+          <span class="font-medium text-accent-text" aria-current="true">
+            DE
+          </span>
+        ) : (
+          <a href="/" class="text-muted transition hover:text-ink">
+            DE
+          </a>
+        )
+      }
+      <span aria-hidden="true" class="text-muted">/</span>
+      {
+        lang === 'en' ? (
+          <span class="font-medium text-accent-text" aria-current="true">
+            EN
+          </span>
+        ) : (
+          <a href="/en/" class="text-muted transition hover:text-ink">
+            EN
+          </a>
+        )
+      }
+    </span>
+  </nav>
+</header>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -11,36 +11,8 @@ const { lang } = Astro.props;
 const t = useTranslations(lang);
 ---
 
-<section class="mx-auto max-w-5xl px-6 pt-6 pb-16 md:pb-24">
-  <div class="flex justify-end">
-    <nav class="flex items-center gap-2 font-mono text-xs uppercase tracking-wider" aria-label="Sprache">
-      {
-        lang === 'de' ? (
-          <span class="font-medium text-accent-text" aria-current="true">
-            DE
-          </span>
-        ) : (
-          <a href="/" class="text-muted transition hover:text-ink">
-            DE
-          </a>
-        )
-      }
-      <span aria-hidden="true" class="text-muted">/</span>
-      {
-        lang === 'en' ? (
-          <span class="font-medium text-accent-text" aria-current="true">
-            EN
-          </span>
-        ) : (
-          <a href="/en/" class="text-muted transition hover:text-ink">
-            EN
-          </a>
-        )
-      }
-    </nav>
-  </div>
-
-  <div class="mt-8 grid items-center gap-10 md:mt-10 md:grid-cols-[1.7fr_1fr] md:gap-14">
+<section class="mx-auto max-w-5xl px-6 pt-8 pb-16 md:pt-14 md:pb-24">
+  <div class="grid items-center gap-10 md:grid-cols-[1.7fr_1fr] md:gap-14">
     <div>
       <p class="flex items-center gap-3 font-mono text-xs uppercase tracking-[0.2em] text-accent-text">
         <span aria-hidden="true" class="h-px w-6 bg-accent"></span>

--- a/src/components/Results.astro
+++ b/src/components/Results.astro
@@ -11,7 +11,7 @@ const t = useTranslations(lang);
 const items = [1, 2, 3, 4] as const;
 ---
 
-<section class="mx-auto max-w-5xl px-6 pb-16 md:pb-24">
+<section id="schwerpunkte" class="scroll-mt-20 mx-auto max-w-5xl px-6 pb-16 md:pb-24">
   <div class="mb-8 flex items-center gap-3">
     <span class="h-px w-8 bg-accent"></span>
     <span class="font-mono text-xs uppercase tracking-[0.2em] text-accent-text">{t('results.label')}</span>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -24,7 +24,17 @@ export const ui = {
     'results.3.title': 'Hands-on Full-Stack',
     'results.3.desc': 'Frontend, Backend, Infrastruktur. Ich bleibe technisch drin und treffe die Architekturentscheidungen selbst.',
     'results.4.title': 'Agentic Engineering',
-    'results.4.desc': 'Die Umsetzung läuft über mehrere KI-Agenten parallel. Das gibt mir den Output eines Teams, auch wenn ich solo baue.'
+    'results.4.desc': 'Die Umsetzung läuft über mehrere KI-Agenten parallel. Das gibt mir den Output eines Teams, auch wenn ich solo baue.',
+    'nav.highlights': 'Schwerpunkte',
+    'nav.contact': 'Kontakt',
+    'contact.eyebrow': 'Kontakt',
+    'contact.lead': 'Neues Produkt im Kopf?',
+    'contact.leadAccent': 'Lass uns reden.',
+    'footer.imprint': 'Impressum',
+    'footer.privacy': 'Datenschutz',
+    'legal.imprintTitle': 'Impressum',
+    'legal.privacyTitle': 'Datenschutz',
+    'legal.back': 'Zurück zur Startseite'
   },
   en: {
     'hero.eyebrow': '10+ years · from engineer to founder',
@@ -44,6 +54,16 @@ export const ui = {
     'results.3.title': 'Hands-on full-stack',
     'results.3.desc': 'Frontend, backend, infrastructure. I stay technical and make the architecture calls myself.',
     'results.4.title': 'Agentic engineering',
-    'results.4.desc': "The build runs across several AI agents in parallel. That gives me a team's output, even when I build solo."
+    'results.4.desc': "The build runs across several AI agents in parallel. That gives me a team's output, even when I build solo.",
+    'nav.highlights': 'Focus',
+    'nav.contact': 'Contact',
+    'contact.eyebrow': 'Contact',
+    'contact.lead': 'Got a product in mind?',
+    'contact.leadAccent': "Let's talk.",
+    'footer.imprint': 'Imprint',
+    'footer.privacy': 'Privacy',
+    'legal.imprintTitle': 'Imprint',
+    'legal.privacyTitle': 'Privacy',
+    'legal.back': 'Back to home'
   }
 } as const;

--- a/src/pages/datenschutz.astro
+++ b/src/pages/datenschutz.astro
@@ -1,0 +1,63 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { useTranslations } from '../i18n/utils';
+
+const t = useTranslations('de');
+---
+
+<BaseLayout title="Datenschutz — Markus Kollers" lang="de" description="Datenschutzerklärung von markuskollers.de.">
+  <Header lang="de" />
+  <main class="mx-auto max-w-2xl px-6 py-16 md:py-24">
+    <h1 class="font-display text-4xl font-light tracking-tight">{t('legal.privacyTitle')}</h1>
+
+    <h2 class="mt-10 font-display text-lg font-medium">1. Verantwortlicher</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Markus Kollers, Fasanenstraße 39b, 65779 Kelkheim, Deutschland. E-Mail: mail@markuskollers.de
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">2. Grundsätzliches</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Diese Website verarbeitet so wenig personenbezogene Daten wie möglich. Es kommen keine Cookies, kein Tracking und keine
+      Analyse-Werkzeuge zum Einsatz.
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">3. Hosting und Server-Logfiles</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Die Website wird bei Netlify (Netlify, Inc., 512 2nd Street, Suite 200, San Francisco, CA 94107, USA) gehostet. Beim Aufruf der Seite
+      verarbeitet der Hosting-Dienstleister technisch notwendige Daten (u. a. IP-Adresse, Datum und Uhrzeit des Zugriffs, aufgerufene Seite,
+      übertragene Datenmenge sowie Browser- und Betriebssystem-Informationen) in Server-Logfiles, um die Auslieferung und Sicherheit der
+      Website zu gewährleisten. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an einer sicheren und stabilen
+      Bereitstellung). Bei einer Übermittlung in die USA stützt sich Netlify u. a. auf Standardvertragsklauseln bzw. das EU-US Data Privacy
+      Framework.
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">4. Schriftarten</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Schriftarten werden lokal von diesem Server ausgeliefert. Beim Aufruf der Seite besteht dafür keine Verbindung zu Servern Dritter
+      (etwa Google Fonts).
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">5. Kontaktaufnahme</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Wenn Sie mich per E-Mail kontaktieren, verarbeite ich Ihre Angaben zur Bearbeitung Ihrer Anfrage. Rechtsgrundlage ist Art. 6 Abs. 1
+      lit. f DSGVO, bei der Anbahnung eines Vertrags Art. 6 Abs. 1 lit. b DSGVO. Ich lösche die Daten, sobald sie nicht mehr erforderlich
+      sind.
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">6. Ihre Rechte</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Sie haben das Recht auf Auskunft, Berichtigung, Löschung, Einschränkung der Verarbeitung, Datenübertragbarkeit sowie Widerspruch.
+      Außerdem können Sie sich bei einer Datenschutz-Aufsichtsbehörde beschweren.
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">Stand</h2>
+    <p class="mt-3 leading-relaxed text-muted">Juli 2026</p>
+
+    <p class="mt-10">
+      <a href="/" class="font-mono text-xs uppercase tracking-wider text-accent-text hover:underline">← {t('legal.back')}</a>
+    </p>
+  </main>
+  <Footer lang="de" />
+</BaseLayout>

--- a/src/pages/en/imprint.astro
+++ b/src/pages/en/imprint.astro
@@ -1,0 +1,40 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { useTranslations } from '../../i18n/utils';
+
+const t = useTranslations('en');
+---
+
+<BaseLayout title="Imprint — Markus Kollers" lang="en" description="Imprint of markuskollers.de.">
+  <Header lang="en" />
+  <main class="mx-auto max-w-2xl px-6 py-16 md:py-24">
+    <h1 class="font-display text-4xl font-light tracking-tight">{t('legal.imprintTitle')}</h1>
+    <p class="mt-4 text-sm text-muted">Legal notice pursuant to § 5 DDG (German Digital Services Act).</p>
+
+    <h2 class="mt-10 font-display text-lg font-medium">Details</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Markus Kollers<br />
+      Fasanenstraße 39b<br />
+      65779 Kelkheim<br />
+      Germany
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">Contact</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Phone: +49 176 811 73 937<br />
+      Email: mail@markuskollers.de
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">Responsible for content pursuant to § 18 (2) MStV</h2>
+    <p class="mt-3 leading-relaxed text-muted">Markus Kollers (address as above)</p>
+
+    <p class="mt-8 leading-relaxed text-muted">This website is a private portfolio. No contracts are concluded through it.</p>
+
+    <p class="mt-10">
+      <a href="/en/" class="font-mono text-xs uppercase tracking-wider text-accent-text hover:underline">← {t('legal.back')}</a>
+    </p>
+  </main>
+  <Footer lang="en" />
+</BaseLayout>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,7 +1,10 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
 import Hero from '../../components/Hero.astro';
 import Results from '../../components/Results.astro';
+import Contact from '../../components/Contact.astro';
+import Footer from '../../components/Footer.astro';
 ---
 
 <BaseLayout
@@ -9,8 +12,11 @@ import Results from '../../components/Results.astro';
   lang="en"
   description="Markus Kollers: product and engineering in one person. I build digital products from concept to running in production."
 >
+  <Header lang="en" />
   <main>
     <Hero lang="en" />
     <Results lang="en" />
+    <Contact lang="en" />
   </main>
+  <Footer lang="en" />
 </BaseLayout>

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -1,0 +1,58 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { useTranslations } from '../../i18n/utils';
+
+const t = useTranslations('en');
+---
+
+<BaseLayout title="Privacy — Markus Kollers" lang="en" description="Privacy policy of markuskollers.de.">
+  <Header lang="en" />
+  <main class="mx-auto max-w-2xl px-6 py-16 md:py-24">
+    <h1 class="font-display text-4xl font-light tracking-tight">{t('legal.privacyTitle')}</h1>
+
+    <h2 class="mt-10 font-display text-lg font-medium">1. Controller</h2>
+    <p class="mt-3 leading-relaxed text-muted">Markus Kollers, Fasanenstraße 39b, 65779 Kelkheim, Germany. Email: mail@markuskollers.de</p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">2. In short</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      This website processes as little personal data as possible. It uses no cookies, no tracking and no analytics tools.
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">3. Hosting and server log files</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      This website is hosted by Netlify (Netlify, Inc., 512 2nd Street, Suite 200, San Francisco, CA 94107, USA). When you open the site,
+      the hosting provider processes technically necessary data (including IP address, date and time of access, page requested, volume of
+      data transferred, and browser and operating system information) in server log files to ensure delivery and security. The legal basis
+      is Art. 6 (1) (f) GDPR (legitimate interest in secure and stable delivery). For transfers to the USA, Netlify relies among other
+      things on standard contractual clauses and the EU-US Data Privacy Framework.
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">4. Fonts</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Fonts are served locally from this server. Opening the site therefore establishes no connection to third-party servers such as Google
+      Fonts.
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">5. Contacting me</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      If you contact me by email, I process your details to handle your request. The legal basis is Art. 6 (1) (f) GDPR, or Art. 6 (1) (b)
+      GDPR where it concerns entering into a contract. I delete the data once it is no longer needed.
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">6. Your rights</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      You have the right to access, rectification, erasure, restriction of processing, data portability and objection. You may also lodge a
+      complaint with a data protection supervisory authority.
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">Last updated</h2>
+    <p class="mt-3 leading-relaxed text-muted">July 2026</p>
+
+    <p class="mt-10">
+      <a href="/en/" class="font-mono text-xs uppercase tracking-wider text-accent-text hover:underline">← {t('legal.back')}</a>
+    </p>
+  </main>
+  <Footer lang="en" />
+</BaseLayout>

--- a/src/pages/impressum.astro
+++ b/src/pages/impressum.astro
@@ -1,0 +1,39 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { useTranslations } from '../i18n/utils';
+
+const t = useTranslations('de');
+---
+
+<BaseLayout title="Impressum — Markus Kollers" lang="de" description="Impressum von markuskollers.de.">
+  <Header lang="de" />
+  <main class="mx-auto max-w-2xl px-6 py-16 md:py-24">
+    <h1 class="font-display text-4xl font-light tracking-tight">{t('legal.imprintTitle')}</h1>
+
+    <h2 class="mt-10 font-display text-lg font-medium">Angaben gemäß § 5 DDG</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Markus Kollers<br />
+      Fasanenstraße 39b<br />
+      65779 Kelkheim<br />
+      Deutschland
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">Kontakt</h2>
+    <p class="mt-3 leading-relaxed text-muted">
+      Telefon: +49 176 811 73 937<br />
+      E-Mail: mail@markuskollers.de
+    </p>
+
+    <h2 class="mt-8 font-display text-lg font-medium">Verantwortlich für den Inhalt nach § 18 Abs. 2 MStV</h2>
+    <p class="mt-3 leading-relaxed text-muted">Markus Kollers (Anschrift wie oben)</p>
+
+    <p class="mt-8 leading-relaxed text-muted">Diese Website ist ein privates Portfolio. Über sie werden keine Verträge geschlossen.</p>
+
+    <p class="mt-10">
+      <a href="/" class="font-mono text-xs uppercase tracking-wider text-accent-text hover:underline">← {t('legal.back')}</a>
+    </p>
+  </main>
+  <Footer lang="de" />
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,10 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
 import Results from '../components/Results.astro';
+import Contact from '../components/Contact.astro';
+import Footer from '../components/Footer.astro';
 ---
 
 <BaseLayout
@@ -9,8 +12,11 @@ import Results from '../components/Results.astro';
   lang="de"
   description="Markus Kollers: Produkt und Engineering in einer Person. Ich baue digitale Produkte vom Konzept bis in den laufenden Betrieb."
 >
+  <Header lang="de" />
   <main>
     <Hero lang="de" />
     <Results lang="de" />
+    <Contact lang="de" />
   </main>
+  <Footer lang="de" />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Nav-Header: Logo, Sektions-Links (Schwerpunkte, Kontakt) und DE/EN-Umschalter. Der Sprachumschalter ist aus dem Hero in den Header gewandert.
- Kontakt-Sektion („Neues Produkt im Kopf? Lass uns reden.") mit Mail-Button und Links zu LinkedIn und GitHub.
- Footer mit Copyright und Links zu Impressum und Datenschutz.
- Impressum und Datenschutz mit echten Inhalten (Betreiber als Privatperson; datenarm: statisches Hosting, selbst gehostete Schriften, kein Tracking) – jeweils DE und EN.
- Damit ist die Startseite ein vollständiger, zweisprachiger One-Pager.

## Release Note
**Kategorie:** Neue Funktion

Die Startseite von markuskollers.de ist jetzt ein vollständiger One-Pager: mit Navigation, einem Kontaktbereich zur direkten Kontaktaufnahme sowie Impressum und Datenschutz. Besucher finden alle Informationen an einer Stelle, auf Deutsch und Englisch.

## Test plan
- [x] `npm run lint` – Prettier + astro check (0 Fehler, 0 Warnungen, 0 Hinweise)
- [x] `npm test` – 4/4 Vitest grün
- [x] `npm run build` – Build inkl. Sitemap; Home DE/EN plus Impressum/Datenschutz (DE/EN)
- [ ] Netlify-Preview prüfen: Nav-Anker scrollen, DE/EN-Wechsel, Rechtsseiten erreichbar

## Confidence
**88/100** – reine UI-/Content-Änderung, lokal komplett grün. Abzug: die Rechtstexte sind sorgfältig, aber Standard – vor dem echten Domain-Launch sollten Anschrift/Telefon bestätigt und die Texte kurz juristisch gegengelesen werden. Noch nicht gegen die echte Netlify-Umgebung getestet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
